### PR TITLE
Fix error in TYPO3 Scheduler module

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,7 +6,7 @@ if (!defined('TYPO3_MODE')) {
 
 $GLOBALS['TYPO3_CONF_VARS']['BE']['XCLASS']['ext/scheduler/class.tx_scheduler.php'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'Classes/XClass/Scheduler.php';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['tx_scheduler']['className'] = 'Scheduler';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Scheduler\\Scheduler']['className'] = 'Scheduler';
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Scheduler\\Scheduler']['className'] = 'AOE\\SchedulerTimeline\\XClass\\Scheduler';
 
     // Get the extensions's configuration
 $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['scheduler_timeline']);


### PR DESCRIPTION
I assume "['tx_scheduler']['className'] " is for legacy 4.x versions so no need to change this.
