### PR TITLE
[BUGFIX] Fix error with xclass using

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,7 +5,7 @@ if (!defined('TYPO3_MODE')) {
 }
 
 $GLOBALS['TYPO3_CONF_VARS']['BE']['XCLASS']['ext/scheduler/class.tx_scheduler.php'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'Classes/XClass/Scheduler.php';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['tx_scheduler']['className'] = 'Scheduler';
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['tx_scheduler']['className'] = 'AOE\\SchedulerTimeline\\XClass\\Scheduler';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Scheduler\\Scheduler']['className'] = 'AOE\\SchedulerTimeline\\XClass\\Scheduler';
 
     // Get the extensions's configuration

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,7 +5,6 @@ if (!defined('TYPO3_MODE')) {
 }
 
 $GLOBALS['TYPO3_CONF_VARS']['BE']['XCLASS']['ext/scheduler/class.tx_scheduler.php'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'Classes/XClass/Scheduler.php';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['tx_scheduler']['className'] = 'AOE\\SchedulerTimeline\\XClass\\Scheduler';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Scheduler\\Scheduler']['className'] = 'AOE\\SchedulerTimeline\\XClass\\Scheduler';
 
     // Get the extensions's configuration


### PR DESCRIPTION
hi, i got a 

> Fatal error: Class 'Scheduler' not found in /typo3_src-6.2.27/typo3/sysext/core/Classes/Utility/GeneralUtility.php on line 4469

if an extension is installed which use `t3lib_div::makeInstance('tx_scheduler')` for example EXT:external_import in Verison 2.5.1 (last Version for 6.2)

so in TYPO3 6.2.x i can't use both extensions, with the pull request this is fixed
